### PR TITLE
Fix shell prompt lint failure (ShellCheck SC2155) on main

### DIFF
--- a/prompt.sh
+++ b/prompt.sh
@@ -108,7 +108,8 @@ prompt_command() {
     fi
 
     # apicli domain context segment (white text on purple)
-    local __apicli_domain="$(apicli_domain_context)"
+    local __apicli_domain
+    __apicli_domain="$(apicli_domain_context)"
     if [ -n "$__apicli_domain" ]; then
         local prev_bg="238"
         [ -n "$(kubernetes_context)" ] && prev_bg="33"


### PR DESCRIPTION
## What
Splits the `local` declaration from the command-substitution assignment for the apicli domain segment in `prompt.sh`, so declaring and assigning no longer happen on the same line.

## Why
PR #17 (the apicli prompt segment) was merged at a commit that still had this issue, so the `lint` job (ShellCheck) is currently failing on `main`. ShellCheck flags `local x="$(cmd)"` as SC2155 because the `local` builtin's own exit status masks the return value of the command substitution. This PR lands the correction and turns `main` green again.

## Change
```
local __apicli_domain
__apicli_domain="$(apicli_domain_context)"
```

## Notes
- Verified locally: `shellcheck prompt.sh` is clean and `apicli_domain_context` still prints `⬡ telephony`.
